### PR TITLE
feat(Redirect All Player Message)

### DIFF
--- a/ProxyServer/src/Network/Handler.cc
+++ b/ProxyServer/src/Network/Handler.cc
@@ -144,11 +144,19 @@ void PacketHandler::RedirectAll(NetworkHandler::Packet &Packet) {
     uint8_t ServerID = Packet.data[0];
     std::cout << "Redirecting all players to server " << (int)ServerID << std::endl;
 
+    std::queue<NetworkHandler::Packet> RedirectQueue;
+
     for (auto client: Lobby.GetClients()) {
         NetworkHandler::Packet RedirectPacket = Packet;
-        RedirectPacket.data[0] = client.first;
-        RedirectPacket.data[1] = ServerID;
-        RedirectPlayer(RedirectPacket);
+        RedirectPacket.data[0] = static_cast<uint8_t>(client.first);
+        RedirectPacket.data[1] = static_cast<uint8_t>(ServerID);
+        RedirectQueue.push(RedirectPacket);
+    }
+
+    for (int i = 0; i < RedirectQueue.size() + 1; i++) {
+        NetworkHandler::Packet packet = RedirectQueue.front();
+        RedirectPlayer(packet);
+        RedirectQueue.pop();
     }
 };
 


### PR DESCRIPTION
**New RedirectPlayers Message.**

To redirect all players to a server you can do sending a packet like this:
**OBS: Network packets should be sent in byte format.** 

``` js
Header:    91        // RedirectAllPlayer Header Number.
Message:   ServerID  // ServerID where players gonna go.
```